### PR TITLE
fix(tests): correct failing Playwright tests for search functionality

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://playwright.deev/docs/intro',
+    baseURL: 'https://playwright.dev/docs/intro',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -5,15 +5,15 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('Realizar una busqueda que no tenga resultados', async ({ page }) => {
-  await page.getByRole('button').click();
+  await page.getByRole('button', {name: 'Search'}).click();
 
   await page.getByPlaceholder('Search docs').click();
 
   await page.getByPlaceholder('Search docs').fill('hascontent');
 
-  expect(page.locator('.DocSearch-NoResults p')).toBeVisible();
+  await expect(page.locator('.DocSearch-NoResults p')).toBeVisible();
 
-  expect(page.locator('.DocSearch-NoResults p')).toHaveText('No results for hascontent');
+  await expect(page.locator('.DocSearch-NoResults p')).toHaveText('No results for "hascontent"');
 
 })
 
@@ -26,7 +26,7 @@ test('Limpiar el input de busqueda', async ({ page }) => {
 
   await searchBox.fill('somerandomtext');
 
-  await expect(searchBox).toHaveText('somerandomtext');
+  await expect(searchBox).toHaveValue('somerandomtext');
 
   await page.getByRole('button', { name: 'Clear the query' }).click();
 
@@ -34,7 +34,8 @@ test('Limpiar el input de busqueda', async ({ page }) => {
 });
 
 test('Realizar una busqueda que genere al menos tenga un resultado', async ({ page }) => {
-  await page.getByRole('button', { name: 'Search ' }).click();
+  await page.getByRole('button', {name: 'Search'}).click();
+
 
   const searchBox = page.getByPlaceholder('Search docs');
 
@@ -42,7 +43,7 @@ test('Realizar una busqueda que genere al menos tenga un resultado', async ({ pa
 
   await page.getByPlaceholder('Search docs').fill('havetext');
 
-  expect(searchBox).toHaveText('havetext');
+  await expect(searchBox).toHaveValue('havetext');
 
   // Verity there are sections in the results
   await page.locator('.DocSearch-Dropdown-Container section').nth(1).waitFor();


### PR DESCRIPTION
Resolved issues in three Playwright tests related to search functionality, ensuring accurate UI interactions and validations:

1.'Perform a search with no results': Modified to verify visibility and correctness of the 'No results' message when a non-existent query is searched.
2.'Clear the search input': Corrected the functionality to ensure the search input is properly cleared.
3.'Perform a search that yields at least one result': Enhanced to confirm that at least one result is displayed for a valid search query and the results container is appropriately populated

These modifications ensure more robust and reliable testing for the search feature, contributing to the overall quality of the application