### PR TITLE
fix: improve search.spec.ts tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 5000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -36,10 +36,12 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://playwright.deev/docs/intro',
+    baseURL: 'https://playwright.dev/docs/intro',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'on-first-retry', 
+    screenshot: 'only-on-failure',
+    headless: false,
   },
 
   /* Configure projects for major browsers */

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -5,44 +5,41 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('Realizar una busqueda que no tenga resultados', async ({ page }) => {
-  await page.getByRole('button').click();
 
+  const keywordSearched = 'hascontent';
+  
+  await page.getByRole('button', { name: 'Search (Ctrl+K)' }).click();
   await page.getByPlaceholder('Search docs').click();
-
-  await page.getByPlaceholder('Search docs').fill('hascontent');
-
-  expect(page.locator('.DocSearch-NoResults p')).toBeVisible();
-
-  expect(page.locator('.DocSearch-NoResults p')).toHaveText('No results for hascontent');
+  await page.getByPlaceholder('Search docs').fill(keywordSearched);
+  await expect(page.locator('.DocSearch-NoResults p')).toBeVisible();
+  await expect(page.locator('.DocSearch-NoResults p')).toHaveText(
+    `No results for "${keywordSearched}"`,
+  );
 
 })
 
 test('Limpiar el input de busqueda', async ({ page }) => {
-  await page.getByRole('button', { name: 'Search' }).click();
 
+  const keywordSearched = 'somerandomtext';
+
+  await page.getByRole('button', { name: 'Search (Ctrl+K)' }).click();
   const searchBox = page.getByPlaceholder('Search docs');
-
   await searchBox.click();
-
-  await searchBox.fill('somerandomtext');
-
-  await expect(searchBox).toHaveText('somerandomtext');
-
+  await searchBox.fill(keywordSearched);
+  await expect(searchBox).toHaveValue(keywordSearched);
   await page.getByRole('button', { name: 'Clear the query' }).click();
-
   await expect(searchBox).toHaveAttribute('value', '');
 });
 
 test('Realizar una busqueda que genere al menos tenga un resultado', async ({ page }) => {
-  await page.getByRole('button', { name: 'Search ' }).click();
 
+  const keybwordSearched = 'havetext';
+
+  await page.getByRole('button', { name: 'Search (Ctrl+K)' }).click();
   const searchBox = page.getByPlaceholder('Search docs');
-
   await searchBox.click();
-
-  await page.getByPlaceholder('Search docs').fill('havetext');
-
-  expect(searchBox).toHaveText('havetext');
+  await page.getByPlaceholder('Search docs').fill(keybwordSearched);
+  await expect(searchBox).toHaveValue(keybwordSearched);
 
   // Verity there are sections in the results
   await page.locator('.DocSearch-Dropdown-Container section').nth(1).waitFor();


### PR DESCRIPTION
fixes included:

1. fixed the search button to retrieve the correct Search button name.
2. added the await keyword to resolve the assertion promise before jumping into the next line of code, this avoids race conditions.
3. updated assertion from toHaveText to toHaveValue since we are working with an input field their content lives in the value attribute.
4. a const variable was added for data integrity across fills and assert arguments.